### PR TITLE
Malformed default config file

### DIFF
--- a/fixations/fix_utils.py
+++ b/fixations/fix_utils.py
@@ -221,7 +221,7 @@ def defaults_init():
         default_cfg = [f"[{CFG_FILE_SECTION_MAIN}]",
                        f"{CFG_FILE_KEY_DATA_DIR_PATH} = {DEFAULT_DATA_DIR_PATH}",
                        f"{CFG_FILE_KEY_FIX_VERSION} = {DEFAULT_FIX_VERSION}",
-                       f"{CFG_FILE_KEY_STORE_PATH} = {DEFAULT_STORE_PATH}"
+                       f"{CFG_FILE_KEY_STORE_PATH} = {DEFAULT_STORE_PATH}",
                        f"{CFG_FILE_KEY_LOOKUP_URL_TEMPLATE} = {DEFAULT_LOOKUP_URL_TEMPLATE}",
                        f"{CFG_ADDITIONAL_FIX_DEFINITIONS_CACHE_PATH} = {DEFAULT_ADDITIONAL_FIX_DEFINITIONS_CACHE_PATH}"
                        ]


### PR DESCRIPTION
Missing comma results in a default config file like this:

```ini
[main]
data_dir_path = /home/ac3673/.fixations
fix_version = 4.2
store_path = /home/ac3673/.fixations/store.dblookup_url_template = https://www.onixs.biz/fix-dictionary/${fix_version}/tagnum_${tag_num}.html
additional_fix_definition_path = /tmp/additional_fix_definitions.txt
```

Running will give you error:

```
ERROR: creating sqlite3 db with path:/home/ac3673/.fixations/store.dblookup_url_template = https://www.onixs.biz/fix-dictionary/${fix_version}/tagnum_${tag_num}.html with exception:unable to open database file. Using in-memory db instead
```